### PR TITLE
feat: PR/이슈 코멘트 알림에 본문 포함

### DIFF
--- a/internal/event/callback/issue.go
+++ b/internal/event/callback/issue.go
@@ -18,7 +18,16 @@ const (
 	issueOpenedTitle               = ":rotating_light: %s New issue opened! %s by %s"
 	issueAssignedTitleFormat       = ":pray: %s assigned to %s"
 	issueClosedTitleFormat         = ":x: %s closed by %s"
+	commentBodyMaxRunes            = 100
 )
+
+func truncateRunes(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	return string(runes[:max]) + "..."
+}
 
 func NewIssueCommentCreated(commonSvc *svc.CommonSvc, issueSvc *svc.IssueSvc) *IssueCommentCreated {
 	return &IssueCommentCreated{
@@ -85,9 +94,11 @@ func (cb *IssueCommentCreated) buildMessage(ctx context.Context, installCtx gith
 		title = fmt.Sprintf(issueCommentCreatedTitleFormat, mentionTexts.String(), model.InlineLink(event.Issue.GetHTMLURL(), "issue"), sender)
 	}
 
-	return model.NewMessage(
-		model.NewTextBlock(title),
-	), nil
+	blocks := []model.MessageBlock{model.NewTextBlock(title)}
+	if body := truncateRunes(event.Comment.GetBody(), commentBodyMaxRunes); body != "" {
+		blocks = append(blocks, model.NewTextBlock(body))
+	}
+	return model.NewMessage(blocks...), nil
 }
 
 func NewIssuesEventOpened(commonSvc *svc.CommonSvc, issueSvc *svc.IssueSvc) *IssuesEventOpened {

--- a/internal/event/callback/issue.go
+++ b/internal/event/callback/issue.go
@@ -96,7 +96,7 @@ func (cb *IssueCommentCreated) buildMessage(ctx context.Context, installCtx gith
 
 	blocks := []model.MessageBlock{model.NewTextBlock(title)}
 	if body := truncateRunes(event.Comment.GetBody(), commentBodyMaxRunes); body != "" {
-		blocks = append(blocks, model.NewTextBlock(body))
+		blocks = append(blocks, model.NewTextBlock(model.EscapedString(body)))
 	}
 	return model.NewMessage(blocks...), nil
 }


### PR DESCRIPTION
## Summary
- PR/이슈 코멘트 알림 시 코멘트 본문을 두 번째 텍스트 블록으로 포함
- 본문이 길어질 수 있어 100 rune 길이 제한 (초과 시 `...` 으로 truncate) -> 200자 해도 될 것 같기도 하구요
- 본문이 비어있는 경우엔 블록을 추가하지 않음

### 100자는 이런느낌
<img width="580" height="102" alt="Channel Talk 2026-05-14 14 12 11" src="https://github.com/user-attachments/assets/092751f2-ce53-4c2e-9bb7-14292e4483a3" />

### 200자는 이런느낌
<img width="605" height="149" alt="Channel Talk 2026-05-14 14 11 59" src="https://github.com/user-attachments/assets/6cc1af41-0683-4a3e-b913-1906f3cdd060" />

### 300자는 이런느낌
<img width="609" height="187" alt="Google Chrome 2026-05-14 14 12 18" src="https://github.com/user-attachments/assets/11e36a68-8c6d-4ab9-96c3-dbc42ccaf5e7" />

## Test plan
- [ ] PR 코멘트 작성 시 알림에 본문이 함께 표시되는지 확인
- [ ] 100자 초과 코멘트가 `...` 으로 잘리는지 확인
- [ ] 한글이 rune 단위로 안전하게 잘리는지 확인
- [ ] 이슈 코멘트에서도 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * GitHub 이슈 댓글이 포함된 메시지의 형식을 개선했습니다. 이제 댓글 본문이 최대 길이로 제한되며 안전하게 처리됩니다. 댓글 본문이 없거나 너무 길면 자동으로 제외됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/cht-app-github/pull/3)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->