### PR TITLE
feat: PR 리뷰 알림에 본문 포함

### DIFF
--- a/internal/event/callback/pull_request.go
+++ b/internal/event/callback/pull_request.go
@@ -234,9 +234,11 @@ func (cb *PullRequestReviewEventSubmitted) buildMessage(ctx context.Context, ins
 		title = fmt.Sprintf(pullRequestReviewCommentedTitleFormat, mentionTexts.String(), model.InlineLink(event.PullRequest.GetHTMLURL(), "pull request"), senderManager)
 	}
 
-	return model.NewMessage(
-		model.NewTextBlock(title),
-	), nil
+	blocks := []model.MessageBlock{model.NewTextBlock(title)}
+	if body := truncateRunes(event.Review.GetBody(), commentBodyMaxRunes); body != "" {
+		blocks = append(blocks, model.NewTextBlock(model.EscapedString(body)))
+	}
+	return model.NewMessage(blocks...), nil
 }
 
 func NewPullRequestEventReviewRequested(commonSvc *svc.CommonSvc, issueSvc *svc.IssueSvc) *PullRequestEventReviewRequested {


### PR DESCRIPTION
## Summary
- PR Review (Approve / Comment / Request changes) 시 본문이 있으면 알림 메시지에 포함
- IssueCommentCreated 와 동일한 패턴: 100 rune truncate + EscapedString
- 본문이 비어있는 경우 (예: 본문 없이 Approve만) 블록 추가 안 함

## Test plan
- [ ] PR Review에 본문 작성 후 Submit → 알림에 본문 포함되는지 확인
- [ ] 본문 없이 Approve만 → 알림에 title만 표시되는지 확인
- [ ] 100자 초과 시 \`...\` 으로 잘리는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * Pull Request 리뷰 이벤트 메시지에 리뷰 본문 내용이 포함되도록 개선했습니다. 이제 리뷰 승인(approved) 및 코멘트(commented) 이벤트에서 제목과 함께 리뷰 본문이 표시됩니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/cht-app-github/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->