### PR TITLE
feat: PR diff inline 코멘트 알림 핸들러 추가

### DIFF
--- a/internal/event/callback/pull_request_review_comment.go
+++ b/internal/event/callback/pull_request_review_comment.go
@@ -1,0 +1,103 @@
+package callback
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/cbrgm/githubevents/githubevents"
+	libgithub "github.com/google/go-github/v60/github"
+
+	"github.com/channel-io/cht-app-github/internal/channel/model"
+	"github.com/channel-io/cht-app-github/internal/event/svc"
+	"github.com/channel-io/cht-app-github/internal/github"
+)
+
+const (
+	pullRequestReviewCommentInlineTitleFormat = ":thinking_face::speech_balloon: %s %s %s commented by %s"
+)
+
+func NewPullRequestReviewCommentEventCreated(commonSvc *svc.CommonSvc, issueSvc *svc.IssueSvc) *PullRequestReviewCommentEventCreated {
+	return &PullRequestReviewCommentEventCreated{
+		commonSvc: commonSvc,
+		issueSvc:  issueSvc,
+	}
+}
+
+type PullRequestReviewCommentEventCreated struct {
+	commonSvc *svc.CommonSvc
+	issueSvc  *svc.IssueSvc
+}
+
+func (cb *PullRequestReviewCommentEventCreated) Register(handler *githubevents.EventHandler) {
+	handler.OnPullRequestReviewCommentEventCreated(func(deliveryID string, eventName string, event *libgithub.PullRequestReviewCommentEvent) error {
+		if isSentFromBot(event.Sender) {
+			return nil
+		}
+
+		installCtx := github.NewInstallationContext(
+			event.Installation.GetID(),
+			event.Org.GetLogin(),
+		)
+		ctx := context.TODO()
+		issueNumber := event.PullRequest.GetNumber()
+		message, err := cb.buildMessage(ctx, installCtx, event)
+		if err != nil {
+			return err
+		}
+		return cb.issueSvc.SyncIssueWithChannelTalk(ctx, installCtx, event.Repo.GetName(), issueNumber, message)
+	})
+}
+
+func (cb *PullRequestReviewCommentEventCreated) buildMessage(ctx context.Context, installCtx github.InstallationContext, event *libgithub.PullRequestReviewCommentEvent) (*model.Message, error) {
+	var mentionTexts bytes.Buffer
+	if len(event.PullRequest.Assignees) > 0 {
+		for i, assignee := range event.PullRequest.Assignees {
+			if i > 0 {
+				mentionTexts.WriteString(" ")
+			}
+			mentionText, err := cb.commonSvc.BuildManagerMentionTextByGithubUsername(ctx, installCtx, event.Repo.GetName(), assignee.GetLogin())
+			if err != nil {
+				return nil, err
+			}
+			mentionTexts.WriteString(mentionText)
+		}
+	} else {
+		mentionText, err := cb.commonSvc.BuildManagerMentionTextByGithubUsername(ctx, installCtx, event.Repo.GetName(), event.PullRequest.User.GetLogin())
+		if err != nil {
+			return nil, err
+		}
+		mentionTexts.WriteString(mentionText)
+	}
+
+	sender, err := cb.commonSvc.FindManagerNameByGithubUsername(ctx, installCtx, event.Repo.GetName(), event.Sender.GetLogin())
+	if err != nil {
+		return nil, err
+	}
+
+	fileRef := buildCommentFileRef(event.Comment)
+	title := fmt.Sprintf(
+		pullRequestReviewCommentInlineTitleFormat,
+		mentionTexts.String(),
+		model.InlineLink(event.PullRequest.GetHTMLURL(), "pull request"),
+		model.InlineLink(event.Comment.GetHTMLURL(), fileRef),
+		sender,
+	)
+
+	blocks := []model.MessageBlock{model.NewTextBlock(title)}
+	if body := truncateRunes(event.Comment.GetBody(), commentBodyMaxRunes); body != "" {
+		blocks = append(blocks, model.NewTextBlock(model.EscapedString(body)))
+	}
+	return model.NewMessage(blocks...), nil
+}
+
+func buildCommentFileRef(comment *libgithub.PullRequestComment) string {
+	path := comment.GetPath()
+	if path == "" {
+		return "comment"
+	}
+	if line := comment.GetLine(); line > 0 {
+		return fmt.Sprintf("%s:L%d", path, line)
+	}
+	return path
+}

--- a/internal/event/callback/pull_request_review_comment.go
+++ b/internal/event/callback/pull_request_review_comment.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/cbrgm/githubevents/githubevents"
 	libgithub "github.com/google/go-github/v60/github"
@@ -15,18 +17,26 @@ import (
 
 const (
 	pullRequestReviewCommentInlineTitleFormat = ":thinking_face::speech_balloon: %s %s %s commented by %s"
+	inlineCommentDedupTTL                     = 1 * time.Hour
 )
 
-func NewPullRequestReviewCommentEventCreated(commonSvc *svc.CommonSvc, issueSvc *svc.IssueSvc) *PullRequestReviewCommentEventCreated {
+func NewPullRequestReviewCommentEventCreated(commonSvc *svc.CommonSvc, issueSvc *svc.IssueSvc, githubSvc github.Service) *PullRequestReviewCommentEventCreated {
 	return &PullRequestReviewCommentEventCreated{
 		commonSvc: commonSvc,
 		issueSvc:  issueSvc,
+		githubSvc: githubSvc,
 	}
 }
 
 type PullRequestReviewCommentEventCreated struct {
 	commonSvc *svc.CommonSvc
 	issueSvc  *svc.IssueSvc
+	githubSvc github.Service
+	// processedReviewIDs claims each review_id at most once so that a batched
+	// review submission with N inline comments yields at most one inline
+	// notification. Entries auto-expire after inlineCommentDedupTTL.
+	// Single-replica assumption.
+	processedReviewIDs sync.Map
 }
 
 func (cb *PullRequestReviewCommentEventCreated) Register(handler *githubevents.EventHandler) {
@@ -35,17 +45,46 @@ func (cb *PullRequestReviewCommentEventCreated) Register(handler *githubevents.E
 			return nil
 		}
 
+		reviewID := event.Comment.GetPullRequestReviewID()
+		if reviewID != 0 {
+			if _, claimed := cb.processedReviewIDs.LoadOrStore(reviewID, struct{}{}); claimed {
+				return nil
+			}
+			cb.scheduleDedupCleanup(reviewID)
+		}
+
 		installCtx := github.NewInstallationContext(
 			event.Installation.GetID(),
 			event.Org.GetLogin(),
 		)
 		ctx := context.TODO()
-		issueNumber := event.PullRequest.GetNumber()
+		repo := event.Repo.GetName()
+		prNumber := event.PullRequest.GetNumber()
+
+		// Wrapper body 가 있으면 PullRequestReviewEventSubmitted 핸들러가 처리하므로
+		// inline 알림은 보내지 않는다 (사용자 피드백 반영: body 없을 때만 inline 노출).
+		if reviewID != 0 {
+			review, err := cb.githubSvc.FetchReview(ctx, installCtx, repo, prNumber, reviewID)
+			if err != nil {
+				cb.processedReviewIDs.Delete(reviewID)
+				return err
+			}
+			if review.GetBody() != "" {
+				return nil
+			}
+		}
+
 		message, err := cb.buildMessage(ctx, installCtx, event)
 		if err != nil {
 			return err
 		}
-		return cb.issueSvc.SyncIssueWithChannelTalk(ctx, installCtx, event.Repo.GetName(), issueNumber, message)
+		return cb.issueSvc.SyncIssueWithChannelTalk(ctx, installCtx, repo, prNumber, message)
+	})
+}
+
+func (cb *PullRequestReviewCommentEventCreated) scheduleDedupCleanup(reviewID int64) {
+	time.AfterFunc(inlineCommentDedupTTL, func() {
+		cb.processedReviewIDs.Delete(reviewID)
 	})
 }
 

--- a/internal/eventfx/fx.go
+++ b/internal/eventfx/fx.go
@@ -33,6 +33,7 @@ var Option = fx.Options(
 		eventCallback(callback.NewPullRequestEventOpened),
 		eventCallback(callback.NewPullRequestEventClosed),
 		eventCallback(callback.NewPullRequestReviewEventSubmitted),
+		eventCallback(callback.NewPullRequestReviewCommentEventCreated),
 		eventCallback(callback.NewPullRequestEventReviewRequested),
 		eventCallback(callback.NewPullRequestEventReviewRequestRemoved),
 		eventCallback(callback.NewPullRequestEventAssigned),

--- a/internal/github/svc.go
+++ b/internal/github/svc.go
@@ -29,6 +29,7 @@ type Service interface {
 	CreateComment(ctx context.Context, installCtx InstallationContext, repository string, number int, body string) error
 	ListPullRequestNumberByCommitSHA(ctx context.Context, installCtx InstallationContext, repoName, sha string, predicates ...FilterPullRequestPredicate) ([]*github.PullRequest, error)
 	FetchPullRequest(ctx context.Context, installCtx InstallationContext, repository string, number int) (*github.PullRequest, error)
+	FetchReview(ctx context.Context, installCtx InstallationContext, repository string, prNumber int, reviewID int64) (*github.PullRequestReview, error)
 	AddAssigneeToIssue(ctx context.Context, installCtx InstallationContext, repository string, number int, assignees []string) error
 	FindAppInstallationID(ctx context.Context, org string) (*int64, error)
 	ListReviewRequestedPullRequest(ctx context.Context, installCtx InstallationContext, user string) ([]*github.Issue, error)
@@ -221,6 +222,18 @@ func (s *ServiceImpl) FetchPullRequest(ctx context.Context, installCtx Installat
 		return nil, err
 	}
 	return issue, nil
+}
+
+func (s *ServiceImpl) FetchReview(ctx context.Context, installCtx InstallationContext, repository string, prNumber int, reviewID int64) (*github.PullRequestReview, error) {
+	client, err := s.getInstallationClient(installCtx)
+	if err != nil {
+		return nil, err
+	}
+	review, _, err := client.PullRequests.GetReview(ctx, installCtx.OrgLogin, repository, prNumber, reviewID)
+	if err != nil {
+		return nil, err
+	}
+	return review, nil
 }
 
 func (s *ServiceImpl) AddAssigneeToIssue(ctx context.Context, installCtx InstallationContext, repository string, number int, assignees []string) error {


### PR DESCRIPTION
## Summary
Files Changed 탭 inline 코멘트 (\`pull_request_review_comment\` 이벤트) 알림 핸들러 신규 추가 + 다음 두 가지 노이즈 감소 처리.

### 동작
1. **review_id 단위 dedup** — 한 리뷰에 inline 코멘트 N개 → 알림은 **1개만** (sync.Map 기반 in-memory, 1h TTL).
2. **wrapper body 가 있으면 skip** — review wrapper 본문이 있으면 inline 알림은 보내지 않고 \`PullRequestReviewEventSubmitted\` 핸들러에 양보 (\`body 없을때만 inline에서 아무거나 하나 뽑아서 보여주는\` 의도). 이를 위해 \`github.Service.FetchReview\` 추가.

### 결과 매트릭스 (한 리뷰 submit 기준)
| wrapper body | inline 코멘트 | 알림 수 |
|---|---|---|
| 있음 | 없음 | 1 (wrapper, body 포함) |
| 있음 | 있음 | 1 (wrapper, body 포함). inline 은 skip |
| 없음 | 있음 | 2 (wrapper title-only + inline 1개) |
| 없음 | 없음 | 1 (wrapper title-only) |

> wrapper body 포함은 별도 PR #4 머지 전제. PR #4 와 독립 mergeable.

### Notes
- mention 대상은 IssueCommentCreated 와 동일 패턴 (PR assignees, 없으면 PR 작성자)
- bot 발신 코멘트는 무시
- 본문 100 rune truncate + EscapedString
- **전제: 봇이 single replica.** multi-replica 시 dedup 깨지고 각 replica 가 알림 1개씩 보낼 수 있음

## Test plan
- [ ] inline 코멘트 1개 → 알림 1개 (본문 포함)
- [ ] inline 코멘트 N개 한 번에 → 알림 1개 (아무거나)
- [ ] review wrapper body + inline 코멘트 → wrapper 알림만, inline 알림 안 옴
- [ ] reply 코멘트 (\`in_reply_to_id != null\`) → 새 리뷰 wrapper 자동 생성, 알림 1개

🤖 Generated with [Claude Code](https://claude.com/claude-code)