### PR TITLE
feat: PR 알림 링크를 PR 루트 대신 코멘트/리뷰 위치로

### DIFF
--- a/internal/event/callback/issue.go
+++ b/internal/event/callback/issue.go
@@ -89,9 +89,9 @@ func (cb *IssueCommentCreated) buildMessage(ctx context.Context, installCtx gith
 
 	var title string
 	if event.Issue.IsPullRequest() {
-		title = fmt.Sprintf(pullRequestReviewCommentedTitleFormat, mentionTexts.String(), model.InlineLink(event.Issue.GetHTMLURL(), "pull request"), sender)
+		title = fmt.Sprintf(pullRequestReviewCommentedTitleFormat, mentionTexts.String(), model.InlineLink(event.Comment.GetHTMLURL(), "pull request"), sender)
 	} else {
-		title = fmt.Sprintf(issueCommentCreatedTitleFormat, mentionTexts.String(), model.InlineLink(event.Issue.GetHTMLURL(), "issue"), sender)
+		title = fmt.Sprintf(issueCommentCreatedTitleFormat, mentionTexts.String(), model.InlineLink(event.Comment.GetHTMLURL(), "issue"), sender)
 	}
 
 	blocks := []model.MessageBlock{model.NewTextBlock(title)}

--- a/internal/event/callback/pull_request.go
+++ b/internal/event/callback/pull_request.go
@@ -229,9 +229,9 @@ func (cb *PullRequestReviewEventSubmitted) buildMessage(ctx context.Context, ins
 	}
 	var title string
 	if event.Review.GetState() == "approved" {
-		title = fmt.Sprintf(pullRequestReviewApprovedTitleFormat, mentionTexts.String(), model.InlineLink(event.PullRequest.GetHTMLURL(), "pull request"), senderManager)
+		title = fmt.Sprintf(pullRequestReviewApprovedTitleFormat, mentionTexts.String(), model.InlineLink(event.Review.GetHTMLURL(), "pull request"), senderManager)
 	} else {
-		title = fmt.Sprintf(pullRequestReviewCommentedTitleFormat, mentionTexts.String(), model.InlineLink(event.PullRequest.GetHTMLURL(), "pull request"), senderManager)
+		title = fmt.Sprintf(pullRequestReviewCommentedTitleFormat, mentionTexts.String(), model.InlineLink(event.Review.GetHTMLURL(), "pull request"), senderManager)
 	}
 
 	return model.NewMessage(


### PR DESCRIPTION
2022년 단테의 피드백 반영 
https://channel.works/root/threads/groups/InHouse-66588/6243fac28cfc90440359/6243fac28cfc90440359
## Summary
사용자 피드백 반영: PR 알림 title 의 'pull request' 링크를 PR root URL 대신 해당 코멘트/리뷰 anchor URL 로 변경. 리뷰가 많은 PR 에서 새로 등록된 코멘트 위치를 바로 찾을 수 있도록 개선.

- 현재: \`https://github.com/.../pull/348\`
- 개선: \`https://github.com/.../pull/348#discussion_r837643710\` (또는 #issuecomment-XYZ / #pullrequestreview-XYZ)

## Changes
- \`IssueCommentCreated\` (PR Conversation / 이슈 코멘트): \`event.Issue.GetHTMLURL\` → \`event.Comment.GetHTMLURL\` (\`#issuecomment-XYZ\` 앵커 포함)
- \`PullRequestReviewEventSubmitted\` (Review submit): \`event.PullRequest.GetHTMLURL\` → \`event.Review.GetHTMLURL\` (\`#pullrequestreview-XYZ\` 앵커 포함)

## Notes
- inline diff 코멘트 핸들러 (별도 PR #5) 는 이미 \`event.Comment.GetHTMLURL\` 사용 중이라 변경 없음
- 다른 PR 이벤트 (opened/closed/ready_for_review/review_requested/assigned/synchronize) 는 특정 코멘트 anchor 가 없으므로 기존 PR root URL 유지

## Test plan
- [ ] PR 에 conversation 코멘트 달면 알림 링크가 해당 코멘트로 점프하는지 확인
- [ ] PR Review (Approve/Comment/Request changes) submit 시 알림 링크가 해당 review block 으로 점프하는지 확인
- [ ] 이슈 코멘트도 동일하게 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 이슈 댓글 알림에서 링크가 정확한 댓글로 이동하도록 수정
  * 풀 리퀘스트 리뷰 알림에서 링크가 정확한 리뷰로 이동하도록 수정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/channel-io/cht-app-github/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->